### PR TITLE
feat: add contact API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Test_Codex
+
+## Environment Variables
+
+The contact form API relies on the following environment variables:
+
+- `CONTACT_EMAIL` – destination address for form submissions.
+- `SMTP_HOST` – SMTP server host.
+- `SMTP_PORT` – SMTP server port (default `587`).
+- `SMTP_USER` – SMTP user name.
+- `SMTP_PASS` – SMTP password.
+
+Ensure these are configured before running the server to allow emails to be sent.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "nodemailer": "^6.9.15"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/api/contact.ts
+++ b/src/api/contact.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import nodemailer from 'nodemailer';
+
+export default async function handler(req: IncomingMessage, res: ServerResponse) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.end();
+    return;
+  }
+
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+
+  req.on('end', async () => {
+    try {
+      const { name, email, company, topic, message } = JSON.parse(body || '{}');
+      if (!name || !email || !message) {
+        res.statusCode = 400;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'Missing required fields' }));
+        return;
+      }
+
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT) || 587,
+        secure: false,
+        auth: process.env.SMTP_USER
+          ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+          : undefined,
+      });
+
+      await transporter.sendMail({
+        to: process.env.CONTACT_EMAIL,
+        from: email,
+        subject: `Contact form: ${topic || 'general'}`,
+        text: `Name: ${name}\nCompany: ${company || ''}\nTopic: ${topic || ''}\n\n${message}`,
+      });
+
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    } catch (err) {
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Failed to send message' }));
+    }
+  });
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -8,6 +8,36 @@ const Contact = () => {
   const { toast } = useToast();
   const [topic, setTopic] = useState("assessment");
 
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = Object.fromEntries(new FormData(e.currentTarget).entries());
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+
+      if (res.ok) {
+        toast({ title: "Merci !", description: "Nous vous contacterons prochainement." });
+        e.currentTarget.reset();
+      } else {
+        toast({
+          variant: "destructive",
+          title: "Erreur",
+          description: "Le message n'a pas pu être envoyé.",
+        });
+      }
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Erreur",
+        description: "Le message n'a pas pu être envoyé.",
+      });
+    }
+  };
+
   return (
     <>
       <SEO
@@ -19,32 +49,26 @@ const Contact = () => {
           <h1 className="text-3xl font-bold">Parler à un Expert</h1>
           <p className="text-muted-foreground mt-2">Nous vous répondrons sous un jour ouvrable.</p>
         </header>
-        <form
-          className="mt-6 space-y-4 border rounded-xl p-6 bg-card"
-          onSubmit={(e) => {
-            e.preventDefault();
-            toast({ title: "Merci !", description: "Nous vous contacterons prochainement." });
-            (e.currentTarget as HTMLFormElement).reset();
-          }}
-        >
+        <form className="mt-6 space-y-4 border rounded-xl p-6 bg-card" onSubmit={handleSubmit}>
           <div className="grid sm:grid-cols-2 gap-4">
             <label className="block">
               <span className="text-sm">Nom</span>
-              <input className="mt-1 w-full rounded-md border bg-background px-3 py-2" required />
+              <input name="name" className="mt-1 w-full rounded-md border bg-background px-3 py-2" required />
             </label>
             <label className="block">
               <span className="text-sm">Email</span>
-              <input type="email" className="mt-1 w-full rounded-md border bg-background px-3 py-2" required />
+              <input name="email" type="email" className="mt-1 w-full rounded-md border bg-background px-3 py-2" required />
             </label>
           </div>
           <label className="block">
             <span className="text-sm">Société</span>
-            <input className="mt-1 w-full rounded-md border bg-background px-3 py-2" />
+            <input name="company" className="mt-1 w-full rounded-md border bg-background px-3 py-2" />
           </label>
           <label className="block">
             <span className="text-sm">De quoi souhaitez-vous discuter ?</span>
             <select
               className="mt-1 w-full rounded-md border bg-background px-3 py-2"
+              name="topic"
               value={topic}
               onChange={(e) => setTopic(e.target.value)}
             >
@@ -83,7 +107,10 @@ const Contact = () => {
 
           <label className="block">
             <span className="text-sm">Parlez-nous de vos défis data</span>
-            <textarea className="mt-1 w-full rounded-md border bg-background px-3 py-2 min-h-28" />
+            <textarea
+              name="message"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 min-h-28"
+            />
           </label>
 
           <div className="pt-2">

--- a/src/types/nodemailer.d.ts
+++ b/src/types/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module 'nodemailer';


### PR DESCRIPTION
## Summary
- add `/api/contact` endpoint using nodemailer
- wire contact form to endpoint with success/error toasts
- document contact form environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c18b2051808326866a3d17cafd4640